### PR TITLE
File controller impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@
   
 * GET http://localhost:8080/users/ ("Возвращает List из всех пользователей")
 * POST http://localhost:8080/users/ ("Создает нового пользователя")
-* GET http://localhost:8080/users/{id} ("Возвращает пользователя по {id}")
+* GET http://localhost:8080/users/id/{id} ("Возвращает пользователя по {id}")
+* GET http://localhost:8080/users/username/{username} ("Возвращает пользователя по {username}")
 * PUT http://localhost:8080/users/{id} ("Обновляет пользователя по {id}")
 * DELETE http://localhost:8080/users/{id} ("Удаляет пользователя по {id}")
 

--- a/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
@@ -28,6 +28,9 @@ public class ImageController {
     @Value("${image.storage.dir}")
     private String imageDir;
 
+    @Value("${max.byte.image.size}")
+    private int maxImageSize;
+
     @GetMapping("/{uuid}")
     @PreAuthorize("hasAuthority('admin:perm')")
     public ResponseEntity<?> read(@PathVariable(name = "uuid") String uuid) {
@@ -37,6 +40,8 @@ public class ImageController {
     @PostMapping("/")
     @PreAuthorize("hasAuthority('admin:perm')")
     public ResponseEntity<?> create(@RequestParam("file") MultipartFile file) {
+        if (file.getSize() > maxImageSize)
+            return new ResponseEntity<>("File size exceeds 5 MB", HttpStatus.BAD_REQUEST);
         return fileControllerService.uploadFile(file, imageExt, uploadPath + "/" + imageDir);
     }
 
@@ -50,6 +55,8 @@ public class ImageController {
     @PreAuthorize("hasAuthority('admin:perm')")
     public ResponseEntity<?> update(@PathVariable(name = "uuid") String uuid,
                                     @RequestParam("file") MultipartFile file) {
+        if (file.getSize() > maxImageSize)
+            return new ResponseEntity<>("File size exceeds 5 MB", HttpStatus.BAD_REQUEST);
         if (delete(uuid).getStatusCode().equals(HttpStatus.OK))
             return create(file);
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
@@ -1,89 +1,57 @@
 package vboled.netcracker.musicstreamer.controllers;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import vboled.netcracker.musicstreamer.service.FileControllerService;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.UUID;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/images")
 public class ImageController {
 
-    @Value("${image.storage.path}")
+    private final FileControllerService fileControllerService = new FileControllerService();
+
+    private final Set<String> imageExt = new HashSet<String>(Arrays.asList(".gif", ".png", ".jpeg", ".jpg"));
+
+    // Путь к директории с файлами
+    @Value("${file.storage.path}")
     private String uploadPath;
 
+    // Название субдиректории
+    @Value("${image.storage.dir}")
+    private String imageDir;
+
     @GetMapping("/{uuid}")
+    @PreAuthorize("hasAuthority('admin:perm')")
     public ResponseEntity<?> read(@PathVariable(name = "uuid") String uuid) {
-        try {
-            byte[] image = Files.readAllBytes(Path.of(uploadPath + "/" + uuid));
-            HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(getContentType(uuid));
-            headers.setContentLength(image.length);
-            return new ResponseEntity<>(image, headers, HttpStatus.OK);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        return fileControllerService.read(uuid, uploadPath + "/" + imageDir);
     }
 
-    private MediaType getContentType(String uuid) {
-        String ext = uuid.substring(uuid.lastIndexOf('.'));
-        if (ext.equals(".jpeg"))
-            return MediaType.IMAGE_JPEG;
-        else if (ext.equals(".png"))
-            return MediaType.IMAGE_PNG;
-        else if (ext.equals(".gif"))
-            return MediaType.IMAGE_GIF;
-        throw new IllegalArgumentException("Wrong file ext.");
-    }
-
-    @PostMapping("")
-    public ResponseEntity<?> create(@RequestParam("file")MultipartFile file) {
-        if (file != null) {
-            File uploadDir = new File(uploadPath);
-            if (!uploadDir.exists()) {
-                uploadDir.mkdir();
-            }
-            String content = file.getContentType();
-            String ext = "." + content.substring(content.indexOf('/') + 1);
-            String newFileName = UUID.randomUUID().toString() + ext;
-            try {
-                file.transferTo(new File(uploadDir.getAbsolutePath() + "/" + newFileName));
-            } catch (IOException e) {
-                e.printStackTrace();
-                new ResponseEntity<>(HttpStatus.NOT_FOUND);
-            }
-            return new ResponseEntity<>(newFileName, HttpStatus.CREATED);
-        }
-        return new ResponseEntity<>("Wrong file", HttpStatus.BAD_REQUEST);
+    @PostMapping("/")
+    @PreAuthorize("hasAuthority('admin:perm')")
+    public ResponseEntity<?> create(@RequestParam("file") MultipartFile file) {
+        return fileControllerService.uploadFile(file, imageExt, uploadPath + "/" + imageDir);
     }
 
     @DeleteMapping("/{uuid}")
+    @PreAuthorize("hasAuthority('admin:perm')")
     public ResponseEntity<?> delete(@PathVariable(name = "uuid") String uuid) {
-        File file = new File(uploadPath + "/" + uuid);
-        if (file.delete())
-            return  new ResponseEntity<>(HttpStatus.OK);
-        return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
+        return fileControllerService.delete(uuid, uploadPath + "/" + imageDir);
     }
 
     @PutMapping("/{uuid}")
+    @PreAuthorize("hasAuthority('admin:perm')")
     public ResponseEntity<?> update(@PathVariable(name = "uuid") String uuid,
-                                    @RequestParam("file")MultipartFile file) {
-        ResponseEntity delResult = delete(uuid);
-        if (delResult.getStatusCode().equals(HttpStatus.OK))
+                                    @RequestParam("file") MultipartFile file) {
+        if (delete(uuid).getStatusCode().equals(HttpStatus.OK))
             return create(file);
-        return delResult;
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import vboled.netcracker.musicstreamer.service.FileControllerService;
+import vboled.netcracker.musicstreamer.service.FileControllerServiceImpl;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -16,7 +17,7 @@ import java.util.Set;
 @RequestMapping("/images")
 public class ImageController {
 
-    private final FileControllerService fileControllerService = new FileControllerService();
+    private final FileControllerService fileControllerService = new FileControllerServiceImpl();
 
     private final Set<String> imageExt = new HashSet<String>(Arrays.asList(".gif", ".png", ".jpeg", ".jpg"));
 

--- a/src/main/java/vboled/netcracker/musicstreamer/controllers/SongController.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/controllers/SongController.java
@@ -7,6 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import vboled.netcracker.musicstreamer.service.FileControllerService;
+import vboled.netcracker.musicstreamer.service.FileControllerServiceImpl;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -16,9 +17,9 @@ import java.util.Set;
 @RequestMapping("/songs")
 public class SongController {
 
-    private final FileControllerService fileControllerService = new FileControllerService();
+    private final FileControllerService fileControllerService = new FileControllerServiceImpl();
 
-    private final Set<String> imageExt = new HashSet<String>(Arrays.asList(".mp3", ".flac", ".ogg", ".wave"));
+    private final Set<String> imageExt = new HashSet<String>(Arrays.asList(".mp3",".ogg", ".wav"));
 
     @Value("${audio.storage.dir}")
     private String audioDir;

--- a/src/main/java/vboled/netcracker/musicstreamer/controllers/SongController.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/controllers/SongController.java
@@ -1,0 +1,55 @@
+package vboled.netcracker.musicstreamer.controllers;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import vboled.netcracker.musicstreamer.service.FileControllerService;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/songs")
+public class SongController {
+
+    private final FileControllerService fileControllerService = new FileControllerService();
+
+    private final Set<String> imageExt = new HashSet<String>(Arrays.asList(".mp3", ".flac", ".ogg", ".wave"));
+
+    @Value("${audio.storage.dir}")
+    private String audioDir;
+
+    @Value("${file.storage.path}")
+    private String uploadPath;
+
+    @GetMapping("/{uuid}")
+    @PreAuthorize("hasAuthority('admin:perm')")
+    public ResponseEntity<?> read(@PathVariable(name = "uuid") String uuid) {
+        return fileControllerService.read(uuid, uploadPath + "/" + audioDir);
+    }
+
+    @PostMapping("/")
+    @PreAuthorize("hasAuthority('admin:perm')")
+    public ResponseEntity<?> create(@RequestParam("file") MultipartFile file) {
+        return fileControllerService.uploadFile(file, imageExt, uploadPath + "/" + audioDir);
+    }
+
+    @DeleteMapping("/{uuid}")
+    @PreAuthorize("hasAuthority('admin:perm')")
+    public ResponseEntity<?> delete(@PathVariable(name = "uuid") String uuid) {
+        return fileControllerService.delete(uuid, uploadPath + "/" + audioDir);
+    }
+
+    @PutMapping("/{uuid}")
+    @PreAuthorize("hasAuthority('admin:perm')")
+    public ResponseEntity<?> update(@PathVariable(name = "uuid") String uuid,
+                                    @RequestParam("file") MultipartFile file) {
+        if (delete(uuid).getStatusCode().equals(HttpStatus.OK))
+            return create(file);
+        return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
+    }
+}

--- a/src/main/java/vboled/netcracker/musicstreamer/service/FileControllerService.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/service/FileControllerService.java
@@ -1,0 +1,78 @@
+package vboled.netcracker.musicstreamer.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public class FileControllerService {
+
+    private MediaType getContentType(String uuid) {
+        String ext = uuid.substring(uuid.lastIndexOf('.'));
+        if (ext.equals(".jpeg") || ext.equals(".jpg"))
+            return MediaType.IMAGE_JPEG;
+        else if (ext.equals(".png"))
+            return MediaType.IMAGE_PNG;
+        else if (ext.equals(".gif"))
+            return MediaType.IMAGE_GIF;
+        else if (ext.equals(".mp3") || ext.equals(".wav") || ext.equals(".flac") || ext.equals(".ogg"))
+            return MediaType.APPLICATION_OCTET_STREAM;
+        throw new IllegalArgumentException("Wrong file ext.");
+    }
+
+    public ResponseEntity<?> read(String uuid, String path) {
+        try {
+            byte[] image = Files.readAllBytes(Path.of(path + "/" + uuid));
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(getContentType(uuid));
+            headers.setContentLength(image.length);
+            return new ResponseEntity<>(image, headers, HttpStatus.OK);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+    }
+
+    public ResponseEntity<?> uploadFile(MultipartFile file, Set<String> extensions, String path) {
+        if (file == null)
+            return new ResponseEntity<>("File is null", HttpStatus.BAD_REQUEST);
+
+        String ext = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        String newFileName;
+
+        if (!extensions.contains(ext))
+            return new ResponseEntity<>("Wrong file extension", HttpStatus.BAD_REQUEST);
+
+        File uploadDir = new File(path);
+        if (!uploadDir.exists()) {
+            uploadDir.mkdir();
+        }
+        newFileName = UUID.randomUUID().toString() + ext;
+
+        try {
+            file.transferTo(new File(uploadDir.getAbsolutePath() + "/" + newFileName));
+        } catch (IOException e) {
+            return new ResponseEntity<>("File wasn't uploaded", HttpStatus.NOT_FOUND);
+        }
+        return new ResponseEntity<>(newFileName, HttpStatus.CREATED);
+    }
+
+    public ResponseEntity<?> delete(String uuid, String path) {
+        File file = new File(path + "/" + uuid);
+        if (file.delete())
+            return  new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
+    }
+}

--- a/src/main/java/vboled/netcracker/musicstreamer/service/FileControllerServiceImpl.java
+++ b/src/main/java/vboled/netcracker/musicstreamer/service/FileControllerServiceImpl.java
@@ -1,12 +1,7 @@
 package vboled.netcracker.musicstreamer.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -16,19 +11,25 @@ import java.nio.file.Path;
 import java.util.Set;
 import java.util.UUID;
 
-@Service
-public class FileControllerService {
 
-    private MediaType getContentType(String uuid) {
+
+@Service
+public class FileControllerServiceImpl implements FileControllerService {
+
+    private String getContentType(String uuid) {
         String ext = uuid.substring(uuid.lastIndexOf('.'));
         if (ext.equals(".jpeg") || ext.equals(".jpg"))
-            return MediaType.IMAGE_JPEG;
+            return "image/jpeg";
         else if (ext.equals(".png"))
-            return MediaType.IMAGE_PNG;
+            return "image/png";
         else if (ext.equals(".gif"))
-            return MediaType.IMAGE_GIF;
-        else if (ext.equals(".mp3") || ext.equals(".wav") || ext.equals(".flac") || ext.equals(".ogg"))
-            return MediaType.APPLICATION_OCTET_STREAM;
+            return "image/gif";
+        else if (ext.equals(".mp3"))
+            return "audio/mpeg";
+        else if (ext.equals(".wav"))
+            return "audio/wav";
+        else if (ext.equals(".ogg"))
+            return "audio/ogg";
         throw new IllegalArgumentException("Wrong file ext.");
     }
 
@@ -36,7 +37,7 @@ public class FileControllerService {
         try {
             byte[] image = Files.readAllBytes(Path.of(path + "/" + uuid));
             HttpHeaders headers = new HttpHeaders();
-            headers.setContentType(getContentType(uuid));
+            headers.add("Content-Type", getContentType(uuid));
             headers.setContentLength(image.length);
             return new ResponseEntity<>(image, headers, HttpStatus.OK);
         } catch (IOException e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,4 +10,9 @@ spring.sql.init.mode=always
 spring.sql.init.schema-locations=classpath*:database/initDB.sql
 #spring.sql.init.data-locations=classpath*:database/populateDB.sql
 
-image.storage.path=images
+image.storage.dir=images
+audio.storage.dir=audio
+file.storage.path=files
+
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ spring.sql.init.schema-locations=classpath*:database/initDB.sql
 image.storage.dir=images
 audio.storage.dir=audio
 file.storage.path=files
+max.byte.image.size=5242880
 
 spring.servlet.multipart.max-file-size=50MB
 spring.servlet.multipart.max-request-size=50MB


### PR DESCRIPTION
Основную логику работы с файлами я вынес сюда:
* https://github.com/vboled/MusicStreamer/blob/00ab5d0d50ba87cb6a092cd61bf5331c104f7899/src/main/java/vboled/netcracker/musicstreamer/service/FileControllerService.java  

А сам запросы для Песен / Изображений вынес в соответствующие контроллеры:
* https://github.com/vboled/MusicStreamer/blob/FileControllerImpl/src/main/java/vboled/netcracker/musicstreamer/controllers/ImageController.java
* https://github.com/vboled/MusicStreamer/blob/FileControllerImpl/src/main/java/vboled/netcracker/musicstreamer/controllers/SongController.java

Сначала была идея сделать общий контроллер FileController и внутри каждого запроса проверять расширение принятого файла и в зависимости от этого использовать подходящий набор валидных расширений и путь до подходящей. Но код получился перегруженным и, как мне кажется, логичнее разделить обращение к изображениям и к аудиофайлам. 
Ссылка на Trello:
https://trello.com/c/y3mPGgOD